### PR TITLE
Update: bump rand to v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [dependencies]
 byteorder = "1"
-rand = "0.4"
+rand = "0.8"
 ff_derive_ce = { version = "0.10.*", optional = true }
 # ff_derive_ce = { path = "ff_derive", optional = true }
 hex = {version = "0.4"}

--- a/ff_derive/src/asm/asm_derive.rs
+++ b/ff_derive/src/asm/asm_derive.rs
@@ -124,9 +124,9 @@ fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenS
             }
         }
 
-        impl ::rand::Rand for #repr {
+        impl ::rand::distributions::Distribution<#repr> for ::rand::distributions::Standard {
             #[inline(always)]
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+            fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> #name {
                 #repr(rng.gen())
             }
         }
@@ -662,11 +662,10 @@ fn prime_field_impl(
             }
         }
 
-        impl ::rand::Rand for #name {
-            /// Computes a uniformly random element using rejection sampling.
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+        impl ::rand::distributions::Distribution<#name> for ::rand::distributions::Standard {
+            fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> #name {
                 loop {
-                    let mut tmp = #name(#repr::rand(rng));
+                    let mut tmp = #name(::rand::distributions::Standard::sample(rng));
 
                     // Mask away the unused bits at the beginning.
                     tmp.0.as_mut()[#top_limb_index] &= 0xffffffffffffffff >> REPR_SHAVE_BITS;

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -194,9 +194,9 @@ fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenS
             }
         }
 
-        impl ::rand::Rand for #repr {
+        impl ::rand::distributions::Distribution<#repr> for ::rand::distributions::Standard {
             #[inline(always)]
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+            fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> #name {
                 #repr(rng.gen())
             }
         }
@@ -1129,11 +1129,10 @@ fn prime_field_impl(
             }
         }
 
-        impl ::rand::Rand for #name {
-            /// Computes a uniformly random element using rejection sampling.
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+        impl ::rand::distributions::Distribution<#name> for ::rand::distributions::Standard {
+            fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> #name {
                 loop {
-                    let mut tmp = #name(#repr::rand(rng));
+                    let mut tmp = #name(::rand::distributions::Standard::sample(rng));
 
                     // Mask away the unused bits at the beginning.
                     tmp.0.as_mut()[#top_limb_index] &= TOP_LIMB_SHAVE_MASK;

--- a/ff_derive_const/src/const_repr.rs
+++ b/ff_derive_const/src/const_repr.rs
@@ -32,9 +32,8 @@ impl<const N: usize> std::fmt::Debug for BigintRepresentation<{N}>
     }
 }
 
-impl<const N: usize> ::rand::Rand for BigintRepresentation<{N}> {
-    #[inline(always)]
-    fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+impl rand::distributions::Distribution<BigintRepresentation<{N}>> for rand::distributions::Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> BigintRepresentation<{N}> {
         let mut s = Self::default();
         for el in s.0.iter_mut() {
             *el = rng.gen();


### PR DESCRIPTION
Since rand v0.5, the trait `rand::Rand` is deprecated.
This pull request shows a possible way to upgrade the rand dep.

(As `cargo fmt` runs, there are several changes which are not related with this change.