### PR TITLE
bump rand to v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ exclude = [
 
 [dependencies]
 byteorder = "1"
-rand = "0.4"
-ff_derive_ce = { version = "0.10.*", optional = true }
-# ff_derive_ce = { path = "ff_derive", optional = true }
+rand = "0.8"
+# ff_derive_ce = { version = "0.10.*", optional = true }
+ff_derive_ce = { path = "ff_derive", optional = true }
 hex = {version = "0.4"}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,6 @@ hex = {version = "0.4"}
 
 [features]
 default = []
+with-serde = ["ff_derive_ce/serde"]
 derive = ["ff_derive_ce"]
 asm_derive = ["derive", "ff_derive_ce/asm"]

--- a/ff_derive/Cargo.toml
+++ b/ff_derive/Cargo.toml
@@ -25,3 +25,4 @@ syn = "1"
 [features]
 default = []
 asm = []
+serde = []

--- a/ff_derive/src/asm/asm_derive.rs
+++ b/ff_derive/src/asm/asm_derive.rs
@@ -105,9 +105,14 @@ pub fn prime_field_asm_impl(input: proc_macro::TokenStream) -> proc_macro::Token
 
 // Implement PrimeFieldRepr for the wrapped ident `repr` with `limbs` limbs.
 fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenStream {
+    let derive = if cfg!(feature = "serde") {
+        quote! { #[derive(Copy, Clone, PartialEq, Eq, Default, ::serde::Serialize, ::serde::Deserialize)] }
+    } else {
+        quote! { #[derive(Copy, Clone, PartialEq, Eq, Default)] }
+    };
     quote! {
 
-        #[derive(Copy, Clone, PartialEq, Eq, Default)]
+        #derive
         pub struct #repr(
             pub [u64; #limbs]
         );

--- a/ff_derive/src/asm/asm_derive.rs
+++ b/ff_derive/src/asm/asm_derive.rs
@@ -124,9 +124,9 @@ fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenS
             }
         }
 
-        impl ::rand::Rand for #repr {
+        impl ::rand::distributions::Distribution<#repr> for ::rand::distributions::Standard {
             #[inline(always)]
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+            fn rand<R: ::rand::Rng>(rng: &mut R) -> #repr {
                 #repr(rng.gen())
             }
         }
@@ -662,11 +662,11 @@ fn prime_field_impl(
             }
         }
 
-        impl ::rand::Rand for #name {
+        impl ::rand::distributions::Distribution<#name> for ::rand::distributions::Standard {
             /// Computes a uniformly random element using rejection sampling.
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+            fn rand<R: ::rand::Rng>(rng: &mut R) -> #name {
                 loop {
-                    let mut tmp = #name(#repr::rand(rng));
+                    let mut tmp = #name(::rand::distributions::Standard.sample(rng));
 
                     // Mask away the unused bits at the beginning.
                     tmp.0.as_mut()[#top_limb_index] &= 0xffffffffffffffff >> REPR_SHAVE_BITS;

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -175,9 +175,14 @@ fn fetch_attr(name: &str, attrs: &[syn::Attribute]) -> Option<String> {
 
 // Implement PrimeFieldRepr for the wrapped ident `repr` with `limbs` limbs.
 fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenStream {
+    let derive = if cfg!(feature = "serde") {
+        quote! { #[derive(Copy, Clone, PartialEq, Eq, Default, ::serde::Serialize, ::serde::Deserialize)] }
+    } else {
+        quote! { #[derive(Copy, Clone, PartialEq, Eq, Default)] }
+    };
     quote! {
-
-        #[derive(Copy, Clone, PartialEq, Eq, Default)]
+        
+        #derive
         pub struct #repr(
             pub [u64; #limbs]
         );

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -163,9 +163,7 @@ fn fetch_attr(name: &str, attrs: &[syn::Attribute]) -> Option<String> {
                         }
                     }
                 }
-                _ => {
-                    panic!("attribute {} should be a string", name);
-                }
+                _ => continue
             }
         }
     }

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -194,9 +194,8 @@ fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenS
             }
         }
 
-        impl ::rand::Rand for #repr {
-            #[inline(always)]
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+        impl ::rand::distributions::Distribution<#repr> for ::rand::distributions::Standard {
+            fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> #repr {
                 #repr(rng.gen())
             }
         }
@@ -1129,11 +1128,11 @@ fn prime_field_impl(
             }
         }
 
-        impl ::rand::Rand for #name {
+        impl ::rand::distributions::Distribution<#name> for ::rand::distributions::Standard {
             /// Computes a uniformly random element using rejection sampling.
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+            fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> #name {
                 loop {
-                    let mut tmp = #name(#repr::rand(rng));
+                    let mut tmp = #name(::rand::distributions::Standard.sample(rng));
 
                     // Mask away the unused bits at the beginning.
                     tmp.0.as_mut()[#top_limb_index] &= TOP_LIMB_SHAVE_MASK;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate byteorder;
 extern crate rand;
 extern crate hex as hex_ext;
+use rand::distributions::{Distribution, Standard};
 pub mod hex {
     pub use hex_ext::*;
 }
@@ -20,9 +21,13 @@ use std::fmt;
 use std::hash;
 use std::io::{self, Read, Write};
 
+/// Backwards compatiablity Marker Rand trait
+pub trait Rand: Sized {}
+impl<T> Rand for T where Standard: Distribution<T> { }
+
 /// This trait represents an element of a field.
 pub trait Field:
-    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static + rand::Rand + hash::Hash + Default
+    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static + Rand + hash::Hash + Default
 {
     /// Returns the zero element of the field, the additive identity.
     fn zero() -> Self;
@@ -106,7 +111,7 @@ pub trait PrimeFieldRepr:
     + fmt::Debug
     + fmt::Display
     + 'static
-    + rand::Rand
+    + Rand
     + AsRef<[u64]>
     + AsMut<[u64]>
     + From<u64>

--- a/tester/Cargo.toml
+++ b/tester/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 ff = {package = "ff_ce", path = "../", features = ["derive"]}
-rand = "0.4"
+rand = "0.8"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/tester/src/mul_variant0.rs
+++ b/tester/src/mul_variant0.rs
@@ -37,9 +37,9 @@ const NEGATIVE_ONE: Fs = Fs(FsRepr([0xaa9f02ab1d6124de, 0xb3524a6466112932, 0x73
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug, Hash)]
 pub struct FsRepr(pub [u64; 4]);
 
-impl ::rand::Rand for FsRepr {
+impl ::rand::distributions::Distribution<FsRepr> for ::rand::distributions::Standard {
     #[inline(always)]
-    fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
+    fn rand<R: ::rand::Rng>(rng: &mut R) -> FsRepr {
         FsRepr(rng.gen())
     }
 }
@@ -235,10 +235,10 @@ impl ::std::fmt::Display for Fs
     }
 }
 
-impl ::rand::Rand for Fs {
+impl ::rand::distributions::Distribution<Fs> for ::rand::distributions::Standard {
     fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
         loop {
-            let mut tmp = Fs(FsRepr::rand(rng));
+            let mut tmp = Fs(::rand::distributions::Standard.sample(rng));
 
             // Mask away the unused bits at the beginning.
             tmp.0.as_mut()[3] &= 0xffffffffffffffff >> REPR_SHAVE_BITS;

--- a/tester/tmp.rs
+++ b/tester/tmp.rs
@@ -138,7 +138,7 @@ mod test_large_cios_field {
             Ok(())
         }
     }
-    impl ::rand::Rand for FrRepr {
+    impl ::rand::distributions::Distribution<FrRepr> for ::rand::distributions::Standard {
         #[inline(always)]
         fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
             FrRepr(rng.gen())
@@ -380,11 +380,11 @@ mod test_large_cios_field {
             ))
         }
     }
-    impl ::rand::Rand for Fr {
+    impl ::rand::distributions::Distribution<Fr> for ::rand::distributions::Standard {
         /// Computes a uniformly random element using rejection sampling.
         fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
             loop {
-                let mut tmp = Fr(FrRepr::rand(rng));
+                let mut tmp = Fr(::rand::distributions::Standard.sample(rng));
                 tmp.0.as_mut()[3usize] &= 0xffffffffffffffff >> REPR_SHAVE_BITS;
                 if tmp.is_valid() {
                     return tmp;


### PR DESCRIPTION
Since rand v0.5, the trait `rand::Rand` is deprecated.
This pull request shows a possible way to upgrade the rand dep. Marker trait is used to avoid huge change to the trait.

(As `cargo fmt` runs, there are several changes which are not related with this change.